### PR TITLE
Omit keyframes and mediaquery from sort css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gochenour",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gochenour",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "license": "MIT",
       "dependencies": {
         "boxen": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -44,5 +44,5 @@
     "test": "vitest && ./restore.sh"
   },
   "type": "module",
-  "version": "1.13.1"
+  "version": "1.13.2"
 }

--- a/src/features/sortCss/sortSingleFile.js
+++ b/src/features/sortCss/sortSingleFile.js
@@ -6,10 +6,42 @@ const testFilepath = '__test__';
 export const sortSingleFile = (filePath = testFilepath, fileName) => {
   const joined = path.join(filePath, fileName);
   const asArrayOfLines = fs.readFileSync(joined, 'utf-8').split('\n');
+  if (fileHasInvalidatingRules(asArrayOfLines)) return;
   const alphabetized = sortEntireFile(asArrayOfLines);
   const result = alphabetized.join('\n');
   fs.writeFileSync(joined, result);
 };
+
+const fileHasInvalidatingRules = (fileAsArrayOfLines) => {
+  let hasInvalidatingRules = false;
+  for (const line in fileAsArrayOfLines) {
+    if (containsCssAtRule(fileAsArrayOfLines[line])) {
+      hasInvalidatingRules = true;
+      break;
+    }
+  }
+  return hasInvalidatingRules;
+};
+
+const containsCssAtRule = (lineOfCssCode) => {
+  const invalidRules = [
+    '@charset',
+    '@color-profile',
+    '@counter-style',
+    '@font-face',
+    '@font-feature-values',
+    '@import',
+    '@keyframes',
+    '@layer',
+    '@media',
+    '@namespace',
+    '@page',
+    '@supports',
+  ];
+  const beginningOfLine = lineOfCssCode.split(' ')[0];
+  const result = invalidRules.includes(beginningOfLine);
+  return result;
+}
 
 const sortEntireFile = (fileAsArrayOfLines) => {
   const ruleSets = produceArrayOfRuleSets(fileAsArrayOfLines);

--- a/src/features/sortCss/test/index.spec.js
+++ b/src/features/sortCss/test/index.spec.js
@@ -10,7 +10,7 @@ vi.mock('../../../common/displayMethods.js');
 
 describe('alphabetizeCssInAllFiles()', ()=>{
   describe('WHEN: This function is invoked,', ()=>{
-    test('THEN: It sorts the rule sets of all files in the directory.', ()=>{
+    test('THEN: It sorts the rule sets of all eligible CSS files in the directory.', ()=>{
       sortSingleFile.mockImplementation(vi.fn());
 
       const dir = '__test__';

--- a/src/features/sortCss/test/mocks.js
+++ b/src/features/sortCss/test/mocks.js
@@ -3,4 +3,5 @@ export const mocks = {
   SINGLE_RULE_SET_UPDATED: '.something {\n  border: 3px;\n  box-shadow: 0px 1px 16px rgba(0, 0, 0, 0.07);\n  margin: 160px;\n  padding: 16px 8px 0 32px;\n  transform: translate(12px, 0px) rotate(-40deg);\n}',
   MULTIPLE_RULE_SETS_ORIGINAL: '.something {\n  padding: 16px 8px 0 32px;\n  transform: translate(12px, 0px) rotate(-40deg);\n  border: 3px;\n  margin: 160px;\n  box-shadow: 0px 1px 16px rgba(0, 0, 0, 0.07);\n}\n\n.a-ruleset {\n    display: flex;\n    flex-direction: row;\n    align-items: center;\n    justify-content: center;\n}',
   MULTIPLE_RULE_SETS_UPDATED: '.a-ruleset {\n  align-items: center;\n  display: flex;\n  flex-direction: row;\n  justify-content: center;\n}\n.something {\n  border: 3px;\n  box-shadow: 0px 1px 16px rgba(0, 0, 0, 0.07);\n  margin: 160px;\n  padding: 16px 8px 0 32px;\n  transform: translate(12px, 0px) rotate(-40deg);\n}',
+  HAS_MEDIA_QUERY: '@keyframes sign {\n  to {\n    stroke-dashoffset: 0;\n  }\n}',
 };

--- a/src/features/sortCss/test/sortSingleFile.spec.js
+++ b/src/features/sortCss/test/sortSingleFile.spec.js
@@ -33,4 +33,14 @@ describe('GIVEN: A CSS file,', ()=>{
       expect(mockWrite).toBeCalledWith(updatedFilePath, mocks.MULTIPLE_RULE_SETS_UPDATED);
     });
   });
+  describe('WHEN: that file contains a CSS at-rule,', ()=>{
+    test('THEN: the file is not processed.', ()=>{
+      const mockWrite = vi.spyOn(fs, 'writeFileSync');
+      fs.readFileSync.mockImplementationOnce(() => mocks.HAS_MEDIA_QUERY);
+
+      sortSingleFile(testFilepath, testFile);
+
+      expect(mockWrite).toBeCalledTimes(0);
+    });
+  });
 });


### PR DESCRIPTION
'WHEN: a file contains a CSS at-rule,'
'THEN: the file is not processed.'